### PR TITLE
feat: implement EasyOcrEngine

### DIFF
--- a/app/engines/easyocr_engine.py
+++ b/app/engines/easyocr_engine.py
@@ -1,7 +1,41 @@
+import asyncio
+import io
+
+import easyocr
+import numpy as np
+from PIL import Image
+
 from app.interfaces.ocr import OcrEngine
-from app.models import OcrResult
+from app.models import OcrBoundingBox, OcrResult
 
 
 class EasyOcrEngine(OcrEngine):
+    def __init__(self, languages: list[str] | None = None, gpu: bool = False) -> None:
+        self._reader = easyocr.Reader(languages or ["en"], gpu=gpu)
+
     async def extract_text(self, image_bytes: bytes) -> OcrResult:
-        raise NotImplementedError("EasyOCR engine not yet implemented")
+        image_array = _bytes_to_array(image_bytes)
+        loop = asyncio.get_running_loop()
+        raw_results = await loop.run_in_executor(
+            None, lambda: self._reader.readtext(image_array)
+        )
+        return _build_ocr_result(raw_results)
+
+
+def _bytes_to_array(image_bytes: bytes) -> np.ndarray:
+    image = Image.open(io.BytesIO(image_bytes))
+    return np.array(image)
+
+
+def _build_ocr_result(
+    raw_results: list[tuple[list[list[float]], str, float]],
+) -> OcrResult:
+    regions = [
+        OcrBoundingBox(
+            text=text,
+            confidence=float(confidence),
+            coordinates=bounding_box,
+        )
+        for bounding_box, text, confidence in raw_results
+    ]
+    return OcrResult(text=" ".join(r.text for r in regions), regions=regions)

--- a/tests/unit/test_easyocr_engine.py
+++ b/tests/unit/test_easyocr_engine.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from app.engines.easyocr_engine import EasyOcrEngine
+from app.models import OcrResult
+
+FAKE_BYTES = b"fake image bytes"
+
+EASYOCR_RAW_RESULT = [
+    ([[0, 0], [200, 0], [200, 50], [0, 50]], "The Great Gatsby", 0.95),
+    ([[0, 60], [200, 60], [200, 100], [0, 100]], "F Scott Fitzgerald", 0.88),
+]
+
+
+@pytest.fixture
+def mock_reader():
+    with patch("app.engines.easyocr_engine.easyocr.Reader") as MockReader:
+        instance = MagicMock()
+        MockReader.return_value = instance
+        yield MockReader, instance
+
+
+@pytest.fixture
+def mock_image():
+    with patch("app.engines.easyocr_engine.Image.open") as mock_open, \
+         patch("app.engines.easyocr_engine.np.array") as mock_array:
+        mock_open.return_value = MagicMock()
+        mock_array.return_value = np.zeros((100, 100, 3), dtype=np.uint8)
+        yield
+
+
+class TestEasyOcrEngineInit:
+    def test_default_params(self, mock_reader):
+        MockReader, _ = mock_reader
+        EasyOcrEngine()
+        MockReader.assert_called_once_with(["en"], gpu=False)
+
+    def test_custom_languages(self, mock_reader):
+        MockReader, _ = mock_reader
+        EasyOcrEngine(languages=["en", "fr"])
+        MockReader.assert_called_once_with(["en", "fr"], gpu=False)
+
+    def test_gpu_flag(self, mock_reader):
+        MockReader, _ = mock_reader
+        EasyOcrEngine(gpu=True)
+        MockReader.assert_called_once_with(["en"], gpu=True)
+
+
+class TestEasyOcrEngineExtractText:
+    @pytest.mark.asyncio
+    async def test_returns_ocr_result(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.return_value = EASYOCR_RAW_RESULT
+        result = await EasyOcrEngine().extract_text(FAKE_BYTES)
+        assert isinstance(result, OcrResult)
+
+    @pytest.mark.asyncio
+    async def test_joined_text(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.return_value = EASYOCR_RAW_RESULT
+        result = await EasyOcrEngine().extract_text(FAKE_BYTES)
+        assert "The Great Gatsby" in result.text
+        assert "F Scott Fitzgerald" in result.text
+
+    @pytest.mark.asyncio
+    async def test_region_count(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.return_value = EASYOCR_RAW_RESULT
+        result = await EasyOcrEngine().extract_text(FAKE_BYTES)
+        assert len(result.regions) == 2
+
+    @pytest.mark.asyncio
+    async def test_region_fields(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.return_value = EASYOCR_RAW_RESULT
+        result = await EasyOcrEngine().extract_text(FAKE_BYTES)
+        first = result.regions[0]
+        assert first.text == "The Great Gatsby"
+        assert first.confidence == pytest.approx(0.95)
+        assert first.coordinates == [[0, 0], [200, 0], [200, 50], [0, 50]]
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.return_value = []
+        result = await EasyOcrEngine().extract_text(FAKE_BYTES)
+        assert result.text == ""
+        assert result.regions == []
+
+    @pytest.mark.asyncio
+    async def test_pil_error_propagates(self, mock_reader):
+        with patch("app.engines.easyocr_engine.Image.open", side_effect=Exception("bad image")):
+            with pytest.raises(Exception, match="bad image"):
+                await EasyOcrEngine().extract_text(b"not valid")
+
+    @pytest.mark.asyncio
+    async def test_reader_error_propagates(self, mock_reader, mock_image):
+        _, reader_instance = mock_reader
+        reader_instance.readtext.side_effect = RuntimeError("model crashed")
+        with pytest.raises(RuntimeError, match="model crashed"):
+            await EasyOcrEngine().extract_text(FAKE_BYTES)


### PR DESCRIPTION
## Summary

- Replaces the `NotImplementedError` stub in `app/engines/easyocr_engine.py` with a full implementation
- `easyocr.Reader` is initialized eagerly in `__init__` so model loading happens once at startup (via FastAPI lifespan), not per-request
- `readtext` (CPU-bound) runs in `run_in_executor` to avoid blocking the async event loop
- Two module-level helpers (`_bytes_to_array`, `_build_ocr_result`) extracted for independent testability
- Adds `tests/unit/test_easyocr_engine.py` with 10 unit tests — all mocked, no model downloads required

## Test plan

- [x] `pytest tests/unit/test_easyocr_engine.py -v` — 10/10 pass
- [x] `pytest tests/unit/ -v` — 50/50 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)