### PR TITLE
feat(telemetry): add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,27 @@ Accepts a multipart image upload (JPEG, PNG, or WebP, max 4 MB) and returns stru
 
 ### `GET /health`
 
-Returns service health status for container orchestration.
+Returns service health status for container orchestration. The `status` field is `"starting"` while models are loading and `"healthy"` once the service is ready to accept requests.
+
+### `GET /metrics`
+
+Exposes Prometheus metrics for monitoring and alerting.
+
+**Metrics included:**
+- HTTP request counts, latencies, and status codes per endpoint
+- Request/response sizes
+- Requests currently in progress
+
+**Integrating with Prometheus** — add to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'cover-detection'
+    static_configs:
+      - targets: ['cover-detection:8000']
+```
+
+Health check requests are excluded from metrics to avoid noise.
 
 ## Architecture
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.staticfiles import StaticFiles
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.config import settings
 from app.engines.gliner_engine import GlinerNlpEngine
@@ -36,11 +37,13 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Book Cover Detection", version="0.1.0", lifespan=lifespan)
+Instrumentator(skip_paths=["/health"]).instrument(app).expose(app, endpoint="/metrics")
 
 
 @app.get("/health", response_model=HealthResponse)
 async def health():
-    return HealthResponse(status="healthy", version="0.1.0")
+    status = "healthy" if analyzer is not None else "starting"
+    return HealthResponse(status=status, version="0.1.0")
 
 
 @app.post("/analyze", response_model=CoverAnalysisResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Book Cover Detection", version="0.1.0", lifespan=lifespan)
-Instrumentator(skip_paths=["/health"]).instrument(app).expose(app, endpoint="/metrics")
+Instrumentator(excluded_handlers=["/health"]).instrument(app).expose(app, endpoint="/metrics")
 
 
 @app.get("/health", response_model=HealthResponse)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ einops>=0.7.0
 timm>=0.9.0
 onnxruntime>=1.17.0
 pydantic-settings>=2.0.0
+prometheus-fastapi-instrumentator>=7.0.0,<8.0.0

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -32,7 +32,7 @@ async def client():
 
 class TestHealthEndpoint:
     @pytest.mark.asyncio
-    async def test_health_returns_200(self, client):
+    async def test_health_returns_200(self, client, mock_analyzer):
         response = await client.get("/health")
         assert response.status_code == 200
         data = response.json()


### PR DESCRIPTION
Closes #41

## Summary

- Adds `prometheus-fastapi-instrumentator` (`>=7.0.0,<8.0.0`) to expose Prometheus metrics at `GET /metrics`
- Health check polls excluded from metrics via `skip_paths=["/health"]` to reduce noise
- Health check now returns `"starting"` while models are loading, `"healthy"` once ready
- README documents the `/metrics` endpoint, available metrics, and a Prometheus scrape config example

## Test plan

- [ ] Rebuild the container (`docker compose up --build`) and confirm `GET /metrics` returns 200 with Prometheus exposition format
- [ ] Confirm `GET /health` returns `"starting"` before models finish loading and `"healthy"` after
- [ ] Verify `/health` requests do not appear in scraped metrics output

🤖 Generated with [Claude Code](https://claude.com/claude-code)