### PR TITLE
feat(logging): add JSON structured logging and pipeline instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,6 @@ ONNX_PROCESSOR_NAME=microsoft/Florence-2-base-ft
 # Default (cloud-safe): 4
 ONNX_NUM_THREADS=4
 
-# Enables ONNX timing logs
-# eg "ONNX timing — processor: 175.7ms, vision_enc: 7269.0ms, text_enc: 1084.3ms, decode: 2230.5ms (106 tokens), postprocess: 7.3ms, total: 10766.9ms"
-# view when running integration tests via "pytest tests/integration/test_pipeline.py -v -s --log-cli-level=INFO "
-ONNX_LOG_TIMING=false
-
 # Disable HuggingFace hub network calls. Set to 1 for offline mode or airgapped deployments.
 # When enabled, all model downloads must already be cached locally (baked into Docker image or pre-downloaded).
 HF_HUB_OFFLINE=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,23 @@ Key settings:
 - `ONNX_NUM_THREADS`: ONNX Runtime thread count (default: 4; tune to match physical cores available)
 - `GLINER_MODEL_REVISION`: Pinned GLiNER model revision to ensure reproducibility
 
+### Logging
+
+All log output is JSON-structured (via `python-json-logger`) with these fields per line: `timestamp`, `level`, `logger_name`, `message`, plus any extra context fields (e.g. `duration_ms`, `ocr_engine`, `error`).
+
+The `level` and `logger_name` fields are promoted as indexed labels by Alloy in the monitoring stack (see [book-share-monitoring#11](https://github.com/landonvance1/book-share-monitoring/issues/11)).
+
+Per-stage ONNX timing (processor, vision_enc, text_enc, decode, postprocess) is always emitted at `DEBUG` level. It is not visible at the default `INFO` level — no env var toggle is needed.
+
+### Metrics
+
+Three custom Prometheus histograms are exposed at `GET /metrics` for pipeline observability:
+- `cover_detection_ocr_duration_seconds`
+- `cover_detection_nlp_duration_seconds`
+- `cover_detection_total_duration_seconds`
+
+These complement the HTTP-level metrics provided by `prometheus-fastapi-instrumentator` and allow Grafana panels showing p50/p95/p99 per pipeline stage.
+
 ### Offline Deployment
 
 The Docker image is designed for airgapped deployments. All required models are baked into the image during build, and `HF_HUB_OFFLINE=1` is set to prevent runtime network calls. This is useful for:

--- a/README.md
+++ b/README.md
@@ -112,9 +112,16 @@ Returns service health status for container orchestration. The `status` field is
 Exposes Prometheus metrics for monitoring and alerting.
 
 **Metrics included:**
-- HTTP request counts, latencies, and status codes per endpoint
+
+HTTP instrumentation (via `prometheus-fastapi-instrumentator`):
+- Request counts, latencies, and status codes per endpoint
 - Request/response sizes
 - Requests currently in progress
+
+Pipeline stage histograms:
+- `cover_detection_ocr_duration_seconds` — time spent in the OCR stage
+- `cover_detection_nlp_duration_seconds` — time spent in the NLP stage
+- `cover_detection_total_duration_seconds` — total analysis time (OCR + NLP)
 
 **Integrating with Prometheus** — add to your `prometheus.yml`:
 
@@ -243,6 +250,8 @@ Key settings:
 - `ONNX_PROCESSOR_NAME`: HuggingFace model name for the ONNX processor (default: `microsoft/Florence-2-base-ft`)
 - `ONNX_NUM_THREADS`: ONNX Runtime thread count (default: 4)
 
+Per-stage ONNX timing is always logged at `DEBUG` level. To enable it, set the log level to `DEBUG` (e.g. via `LOG_LEVEL=DEBUG` if you configure that) rather than using the removed `ONNX_LOG_TIMING` flag.
+
 #### Offline Deployment
 
 The Docker image bakes in all required models (`florence2`, `gliner`, and tokenizer dependencies) during build. Set `HF_HUB_OFFLINE=1` to prevent any runtime network calls—useful for airgapped or unreliable network environments. The Dockerfile does this by default.
@@ -304,6 +313,7 @@ pytest tests/integration/ -v
 ```
 app/
 ├── main.py              # FastAPI app and routes
+├── logging_config.py    # JSON structured logging setup
 ├── interfaces/
 │   ├── ocr.py           # OCR abstract base class
 │   └── nlp.py           # NLP abstract base class

--- a/app/config.py
+++ b/app/config.py
@@ -44,11 +44,6 @@ class Settings(BaseSettings):
     # and significant slowdowns — see benchmark results in issue #12.
     onnx_num_threads: int = 4
 
-    # When true, logs per-stage timing for each ONNX inference call.
-    # Set ONNX_LOG_TIMING=true in the environment or .env to enable.
-    # Default is false to avoid overhead in production.
-    onnx_log_timing: bool = False
-
     # When true, serves the static test webapp at /test/.
     # Set ENABLE_TEST_APP=true in the environment or .env to enable.
     # Disabled by default — not intended for production use.

--- a/app/engines/florence2_onnx_engine.py
+++ b/app/engines/florence2_onnx_engine.py
@@ -41,6 +41,7 @@ class Florence2OnnxEngine(OcrEngine):
         processor_name: str = "microsoft/Florence-2-base-ft",
         intra_op_num_threads: int | None = None,
     ) -> None:
+        t_init = time.perf_counter()
         onnx_dir = Path(model_path) / "onnx"
         suffix = f"_{quantization}" if quantization else ""
         threads = intra_op_num_threads if intra_op_num_threads is not None else settings.onnx_num_threads
@@ -50,18 +51,29 @@ class Florence2OnnxEngine(OcrEngine):
         opts.intra_op_num_threads = threads
         opts.inter_op_num_threads = 1
 
+        t = time.perf_counter()
         self._vision_encoder = ort.InferenceSession(
             str(onnx_dir / f"vision_encoder{suffix}.onnx"), opts
         )
+        logger.debug("Loaded vision_encoder", extra={"elapsed_ms": round((time.perf_counter() - t) * 1000, 1)})
+
+        t = time.perf_counter()
         self._embed_tokens = ort.InferenceSession(
             str(onnx_dir / f"embed_tokens{suffix}.onnx"), opts
         )
+        logger.debug("Loaded embed_tokens", extra={"elapsed_ms": round((time.perf_counter() - t) * 1000, 1)})
+
+        t = time.perf_counter()
         self._encoder = ort.InferenceSession(
             str(onnx_dir / f"encoder_model{suffix}.onnx"), opts
         )
+        logger.debug("Loaded encoder_model", extra={"elapsed_ms": round((time.perf_counter() - t) * 1000, 1)})
+
+        t = time.perf_counter()
         self._decoder = ort.InferenceSession(
             str(onnx_dir / f"decoder_model_merged{suffix}.onnx"), opts
         )
+        logger.debug("Loaded decoder_model_merged", extra={"elapsed_ms": round((time.perf_counter() - t) * 1000, 1)})
 
         self._processor = AutoProcessor.from_pretrained(
             processor_name, trust_remote_code=True, local_files_only=True
@@ -86,6 +98,11 @@ class Florence2OnnxEngine(OcrEngine):
         self._enc_kv_indices = [i for i, n in enumerate(kv_out_names) if ".encoder." in n]
         self._dec_kv_indices = [i for i, n in enumerate(kv_out_names) if ".encoder." not in n]
 
+        logger.info(
+            "Florence2 ONNX engine initialized",
+            extra={"model_path": model_path, "quantization": quantization, "duration_ms": round((time.perf_counter() - t_init) * 1000, 1)},
+        )
+
     def _extract_embedding_weights(self) -> np.ndarray:
         """Run embed_tokens in chunks to build a (vocab_size, embed_dim) weight matrix."""
         weights = np.empty((_VOCAB_SIZE, _EMBED_DIM), dtype=np.float32)
@@ -102,19 +119,18 @@ class Florence2OnnxEngine(OcrEngine):
         return await loop.run_in_executor(None, lambda: self._run_ocr(image))
 
     def _run_ocr(self, image: Image.Image) -> OcrResult:
-        timing = settings.onnx_log_timing
-        t0 = time.perf_counter() if timing else None
+        t0 = time.perf_counter()
         task = "<OCR_WITH_REGION>"
 
         inputs = self._processor(text=task, images=image, return_tensors="np")
-        t_processor = time.perf_counter() if timing else None
+        t_processor = time.perf_counter()
 
         # Stage 1: Vision encoding
         pixel_values = inputs["pixel_values"].astype(np.float32)
         image_features = self._vision_encoder.run(
             None, {"pixel_values": pixel_values}
         )[0]
-        t_vision = time.perf_counter() if timing else None
+        t_vision = time.perf_counter()
 
         # Stage 2: Text embedding (numpy indexing) + encoder
         input_ids = inputs["input_ids"].astype(np.int64)
@@ -129,11 +145,11 @@ class Florence2OnnxEngine(OcrEngine):
             "inputs_embeds": combined_embeds,
             "attention_mask": combined_mask,
         })[0]
-        t_encoder = time.perf_counter() if timing else None
+        t_encoder = time.perf_counter()
 
         # Stage 3: Greedy autoregressive decode
         generated_ids = self._greedy_decode(encoder_hidden, combined_mask)
-        t_decode = time.perf_counter() if timing else None
+        t_decode = time.perf_counter()
 
         # Stage 4: Post-process
         text = self._processor.batch_decode(
@@ -144,21 +160,20 @@ class Florence2OnnxEngine(OcrEngine):
         )
         result = _build_ocr_result(parsed[task])
 
-        if timing:
-            t_end = time.perf_counter()
-            num_tokens = len(generated_ids[0]) if generated_ids else 0
-            logger.info(
-                "ONNX timing — processor: %.1fms, vision_enc: %.1fms, "
-                "text_enc: %.1fms, decode: %.1fms (%d tokens), "
-                "postprocess: %.1fms, total: %.1fms",
-                (t_processor - t0) * 1000,
-                (t_vision - t_processor) * 1000,
-                (t_encoder - t_vision) * 1000,
-                (t_decode - t_encoder) * 1000,
-                num_tokens,
-                (t_end - t_decode) * 1000,
-                (t_end - t0) * 1000,
-            )
+        t_end = time.perf_counter()
+        num_tokens = len(generated_ids[0]) if generated_ids else 0
+        logger.debug(
+            "ONNX timing",
+            extra={
+                "processor_ms": round((t_processor - t0) * 1000, 1),
+                "vision_enc_ms": round((t_vision - t_processor) * 1000, 1),
+                "text_enc_ms": round((t_encoder - t_vision) * 1000, 1),
+                "decode_ms": round((t_decode - t_encoder) * 1000, 1),
+                "num_tokens": num_tokens,
+                "postprocess_ms": round((t_end - t_decode) * 1000, 1),
+                "total_ms": round((t_end - t0) * 1000, 1),
+            },
+        )
 
         return result
 

--- a/app/engines/gliner_engine.py
+++ b/app/engines/gliner_engine.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 
 from app.interfaces.nlp import NlpEngine
 from app.models import NlpAnalysis, OcrResult
+
+logger = logging.getLogger(__name__)
 
 
 def _region_height(region) -> float:
@@ -53,8 +57,11 @@ class GlinerNlpEngine(NlpEngine):
 
     def __init__(self, model_name: str = DEFAULT_MODEL, threshold: float = DEFAULT_THRESHOLD, revision: str | None = None):
         from gliner import GLiNER  # lazy import — gliner is heavy and optional at import time
+        t0 = time.perf_counter()
         self._model = GLiNER.from_pretrained(model_name, revision=revision)
         self._threshold = threshold
+        duration = time.perf_counter() - t0
+        logger.info("GLiNER model loaded", extra={"model": model_name, "duration_ms": round(duration * 1000, 1)})
 
     async def analyze(self, ocr_result: OcrResult) -> NlpAnalysis:
         regions = _regions_with_heights(ocr_result)

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,44 @@
+import datetime
+import logging
+
+from pythonjsonlogger import jsonlogger
+
+
+class _JsonFormatter(jsonlogger.JsonFormatter):
+    """JsonFormatter that emits ISO 8601 timestamps with milliseconds and UTC 'Z' suffix.
+
+    The default datefmt-based formatting omits sub-second precision and timezone info.
+    Alloy uses the timestamp field for event time rather than ingestion time, so the
+    format needs to be unambiguous and parseable by standard ISO 8601 parsers.
+    Example output: "2026-03-28T12:00:00.123Z"
+    """
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        dt = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{int(record.msecs):03d}Z"
+
+
+def setup_logging() -> None:
+    formatter = _JsonFormatter(
+        fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+        rename_fields={
+            "asctime": "timestamp",
+            "levelname": "level",
+            "name": "logger_name",
+        },
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+
+    # Uvicorn installs its own plain-text StreamHandler on startup (via
+    # logging.config.dictConfig). Clear those handlers and enable propagation
+    # so all uvicorn output — including access logs — routes through the root
+    # JSON handler instead.
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        uv_logger = logging.getLogger(name)
+        uv_logger.handlers = []
+        uv_logger.propagate = True

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
@@ -6,8 +7,13 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.config import settings
 from app.engines.gliner_engine import GlinerNlpEngine
+from app.logging_config import setup_logging
 from app.models import CoverAnalysisResponse, HealthResponse
 from app.services.analyzer import CoverAnalyzer
+
+setup_logging()
+
+logger = logging.getLogger(__name__)
 
 ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 MAX_FILE_SIZE = 4 * 1024 * 1024  # 4 MB
@@ -17,7 +23,11 @@ analyzer: CoverAnalyzer | None = None
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Re-apply after uvicorn's own logging.config.dictConfig call, which runs
+    # during server startup and reinstalls plain-text handlers on uvicorn loggers.
+    setup_logging()
     global analyzer
+    logger.info("Starting cover detection service", extra={"ocr_engine": settings.ocr_engine})
     if settings.ocr_engine == "onnx":
         from app.engines.florence2_onnx_engine import Florence2OnnxEngine
         ocr_engine = Florence2OnnxEngine(
@@ -32,6 +42,7 @@ async def lifespan(app: FastAPI):
         )
     nlp_engine = GlinerNlpEngine(revision=settings.gliner_model_revision)
     analyzer = CoverAnalyzer(ocr_engine, nlp_engine)
+    logger.info("Models loaded, service ready", extra={"ocr_engine": settings.ocr_engine})
     yield
     analyzer = None
 
@@ -49,6 +60,10 @@ async def health():
 @app.post("/analyze", response_model=CoverAnalysisResponse)
 async def analyze_cover(file: UploadFile = File(...)):
     if file.content_type not in ALLOWED_CONTENT_TYPES:
+        logger.warning(
+            "Invalid content type rejected",
+            extra={"content_type": file.content_type},
+        )
         raise HTTPException(
             status_code=400,
             detail=f"Invalid content type: {file.content_type}. Accepted: JPEG, PNG, WebP",
@@ -57,6 +72,10 @@ async def analyze_cover(file: UploadFile = File(...)):
     image_bytes = await file.read()
 
     if len(image_bytes) > MAX_FILE_SIZE:
+        logger.warning(
+            "Oversized file rejected",
+            extra={"file_size_bytes": len(image_bytes), "max_bytes": MAX_FILE_SIZE},
+        )
         raise HTTPException(
             status_code=400,
             detail=f"File too large: {len(image_bytes)} bytes. Max: {MAX_FILE_SIZE} bytes",

--- a/app/services/analyzer.py
+++ b/app/services/analyzer.py
@@ -1,6 +1,26 @@
+import logging
+import time
+
+from prometheus_client import Histogram
+
 from app.interfaces.nlp import NlpEngine
 from app.interfaces.ocr import OcrEngine
 from app.models import AnalysisStatus, CoverAnalysisResponse
+
+logger = logging.getLogger(__name__)
+
+_OCR_DURATION = Histogram(
+    "cover_detection_ocr_duration_seconds",
+    "Time spent in the OCR stage",
+)
+_NLP_DURATION = Histogram(
+    "cover_detection_nlp_duration_seconds",
+    "Time spent in the NLP stage",
+)
+_TOTAL_DURATION = Histogram(
+    "cover_detection_total_duration_seconds",
+    "Total analysis time (OCR + NLP)",
+)
 
 
 class CoverAnalyzer:
@@ -13,9 +33,16 @@ class CoverAnalyzer:
         self._nlp = nlp_engine
 
     async def analyze(self, image_bytes: bytes) -> CoverAnalysisResponse:
+        t_start = time.perf_counter()
+
         try:
+            t_ocr_start = time.perf_counter()
             ocr_result = await self._ocr.extract_text(image_bytes)
+            ocr_duration = time.perf_counter() - t_ocr_start
+            _OCR_DURATION.observe(ocr_duration)
+            logger.info("OCR completed", extra={"duration_ms": round(ocr_duration * 1000, 1)})
         except Exception as e:
+            logger.error("OCR failed", extra={"error": str(e)})
             return CoverAnalysisResponse(
                 analysisStatus=AnalysisStatus(
                     is_success=False,
@@ -24,8 +51,13 @@ class CoverAnalyzer:
             )
 
         try:
+            t_nlp_start = time.perf_counter()
             nlp_analysis = await self._nlp.analyze(ocr_result)
+            nlp_duration = time.perf_counter() - t_nlp_start
+            _NLP_DURATION.observe(nlp_duration)
+            logger.info("NLP completed", extra={"duration_ms": round(nlp_duration * 1000, 1)})
         except Exception as e:
+            logger.error("NLP analysis failed", extra={"error": str(e)})
             return CoverAnalysisResponse(
                 analysisStatus=AnalysisStatus(
                     is_success=False,
@@ -33,13 +65,9 @@ class CoverAnalyzer:
                 ),
             )
 
-        except Exception as e:
-            return CoverAnalysisResponse(
-                analysisStatus=AnalysisStatus(
-                    is_success=False,
-                    error_message=f"Book search failed: {e}",
-                ),
-            )
+        total_duration = time.perf_counter() - t_start
+        _TOTAL_DURATION.observe(total_duration)
+        logger.info("Analysis completed", extra={"duration_ms": round(total_duration * 1000, 1)})
 
         return CoverAnalysisResponse(
             analysisStatus=AnalysisStatus(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ timm>=0.9.0
 onnxruntime>=1.17.0
 pydantic-settings>=2.0.0
 prometheus-fastapi-instrumentator>=7.0.0,<8.0.0
+python-json-logger>=2.0.7

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -1,3 +1,6 @@
+import logging
+from unittest.mock import patch
+
 import pytest
 
 from app.models import BookMatch, NlpAnalysis, OcrResult
@@ -42,6 +45,82 @@ class TestCoverAnalyzer:
 
         assert result.analysisStatus.is_success is False
         assert "NLP analysis failed" in result.analysisStatus.error_message
+
+    @pytest.mark.asyncio
+    async def test_successful_pipeline_records_histograms(self, sample_ocr_result, sample_nlp_analysis):
+        ocr = MockOcrEngine(result=sample_ocr_result)
+        nlp = MockNlpEngine(result=sample_nlp_analysis)
+        analyzer = CoverAnalyzer(ocr, nlp)
+
+        with patch("app.services.analyzer._OCR_DURATION") as mock_ocr, \
+             patch("app.services.analyzer._NLP_DURATION") as mock_nlp, \
+             patch("app.services.analyzer._TOTAL_DURATION") as mock_total:
+            await analyzer.analyze(b"fake image bytes")
+
+        mock_ocr.observe.assert_called_once()
+        mock_nlp.observe.assert_called_once()
+        mock_total.observe.assert_called_once()
+        assert mock_ocr.observe.call_args[0][0] >= 0
+        assert mock_nlp.observe.call_args[0][0] >= 0
+        assert mock_total.observe.call_args[0][0] >= 0
+
+    @pytest.mark.asyncio
+    async def test_successful_pipeline_logs_durations(self, sample_ocr_result, sample_nlp_analysis, caplog):
+        ocr = MockOcrEngine(result=sample_ocr_result)
+        nlp = MockNlpEngine(result=sample_nlp_analysis)
+        analyzer = CoverAnalyzer(ocr, nlp)
+
+        with caplog.at_level(logging.INFO, logger="app.services.analyzer"):
+            await analyzer.analyze(b"fake image bytes")
+
+        assert "OCR completed" in caplog.messages
+        assert "NLP completed" in caplog.messages
+        assert "Analysis completed" in caplog.messages
+        ocr_record = next(r for r in caplog.records if r.getMessage() == "OCR completed")
+        assert hasattr(ocr_record, "duration_ms")
+
+    @pytest.mark.asyncio
+    async def test_ocr_failure_logs_error(self, caplog):
+        ocr = MockOcrEngine(error=RuntimeError("OCR crashed"))
+        nlp = MockNlpEngine(result=NlpAnalysis())
+        analyzer = CoverAnalyzer(ocr, nlp)
+
+        with caplog.at_level(logging.ERROR, logger="app.services.analyzer"):
+            await analyzer.analyze(b"fake image bytes")
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert error_records[0].getMessage() == "OCR failed"
+        assert hasattr(error_records[0], "error")
+
+    @pytest.mark.asyncio
+    async def test_nlp_failure_logs_error(self, sample_ocr_result, caplog):
+        ocr = MockOcrEngine(result=sample_ocr_result)
+        nlp = MockNlpEngine(error=RuntimeError("NLP crashed"))
+        analyzer = CoverAnalyzer(ocr, nlp)
+
+        with caplog.at_level(logging.ERROR, logger="app.services.analyzer"):
+            await analyzer.analyze(b"fake image bytes")
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert error_records[0].getMessage() == "NLP analysis failed"
+        assert hasattr(error_records[0], "error")
+
+    @pytest.mark.asyncio
+    async def test_ocr_failure_does_not_record_histograms(self):
+        ocr = MockOcrEngine(error=RuntimeError("OCR crashed"))
+        nlp = MockNlpEngine(result=NlpAnalysis())
+        analyzer = CoverAnalyzer(ocr, nlp)
+
+        with patch("app.services.analyzer._OCR_DURATION") as mock_ocr, \
+             patch("app.services.analyzer._NLP_DURATION") as mock_nlp, \
+             patch("app.services.analyzer._TOTAL_DURATION") as mock_total:
+            await analyzer.analyze(b"fake image bytes")
+
+        mock_ocr.observe.assert_not_called()
+        mock_nlp.observe.assert_not_called()
+        mock_total.observe.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_data_flows_through_pipeline(self):


### PR DESCRIPTION
## Summary

- Adds `python-json-logger` with ISO 8601 timestamps (`2026-03-28T12:00:00.123Z`) — field is `timestamp`, matching the format Alloy's `stage.timestamp` already expects
- Adds three Prometheus histograms for OCR/NLP stage breakdown: `cover_detection_{ocr,nlp,total}_duration_seconds`
- Logs startup events, validation rejections, per-stage completion with `duration_ms`, and errors throughout the pipeline
- Overrides uvicorn loggers at lifespan startup so access logs (including health checks) emit JSON rather than plain text
- Converts ONNX per-stage timing to `DEBUG` level and removes the `ONNX_LOG_TIMING` env var toggle
- Adds ONNX engine init logging (per-model `DEBUG` + total `INFO`)
- Unit tests covering histogram observation, structured log fields, and error logging

Closes #43

## Test plan

- [ ] `pytest tests/unit/test_analyzer.py` — all 9 tests pass
- [ ] Start the service and confirm all log lines (including uvicorn access logs) are JSON with `timestamp`, `level`, `logger_name`, `message`
- [ ] Hit `GET /metrics` and confirm `cover_detection_ocr_duration_seconds`, `cover_detection_nlp_duration_seconds`, and `cover_detection_total_duration_seconds` are present after an `/analyze` request

🤖 Generated with [Claude Code](https://claude.com/claude-code)